### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
     <a href="https://golang.org"><img src="https://img.shields.io/badge/go-1.19+-blue?logo=go" alt="Go version"></a>
     <img src="https://img.shields.io/github/v/tag/goforj/wire?label=version&sort=semver" alt="Latest tag">
     <a href="https://codecov.io/gh/goforj/wire" ><img src="https://codecov.io/github/goforj/wire/graph/badge.svg?token=T7REZRC0G0"/></a>
-    <a href="https://goreportcard.com/report/github.com/goforj/wire"><img src="https://goreportcard.com/badge/github.com/goforj/wire" alt="Go Report Card"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Remove the retired Go Report Card badge from the README. The service no longer reports a grade, so the badge now displays “Retired” instead of a useful quality signal.