### PR TITLE
chore: ignore macOS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store


### PR DESCRIPTION
Adds a repository-wide `.DS_Store` ignore rule so Finder metadata no longer appears in working trees or future commits.